### PR TITLE
Use different docker container with more recent version of Chrome

### DIFF
--- a/lib/commands/test.js
+++ b/lib/commands/test.js
@@ -26,7 +26,7 @@ module.exports = (ctx, options) => {
 
 	args = args.concat([
 		'--name', options.name,
-		'-t', 'samverschueren/node-chromium-xvfb',
+		'-t', 'circleci/node:6-browsers',
 		'bash', '-c', `cd /app && ${install} && npm test${flags}`
 	]);
 


### PR DESCRIPTION
The original container uses an old version of Chrome, which also does not support ChomeHeadless.

Now it uses a container created by CircleCI [link](https://hub.docker.com/r/circleci/node/) with a specific tag (in this case 6-browsers, which include a Chrome browser)

More info on the CircleCI images: [link](https://github.com/circleci/circleci-images)